### PR TITLE
Mortens/split out filesystem gc

### DIFF
--- a/cache/fs.go
+++ b/cache/fs.go
@@ -140,6 +140,7 @@ func (fs *FS) collectGarbageOnce() {
 					continue
 				}
 
+				oldIndex := i + 256*nsIndex
 				for _, entry := range entries {
 					if entry.IsDir() {
 						continue
@@ -151,8 +152,7 @@ func (fs *FS) collectGarbageOnce() {
 
 					// Check if it's the oldest thing we've found in this directory
 					t := fileinfo_atime(entry)
-					oldIndex := i + 256*nsIndex
-					if len(old[oldIndex].uuidAndHash) == 0 || t.Before(old[i].time) {
+					if len(old[oldIndex].uuidAndHash) == 0 || t.Before(old[oldIndex].time) {
 						old[oldIndex].ns = ns
 						old[oldIndex].uuidAndHash = entry.Name() // TODO: Chop off extension
 						old[oldIndex].size = entry.Size()

--- a/cache/fs.go
+++ b/cache/fs.go
@@ -130,9 +130,11 @@ func (fs *FS) collectGarbageOnce() {
 			}
 		}
 
-		// FIXME: This is quite wrong, as we'll only decrement the counter by one of
-		// the elements. (findApproximateOldFiles() really should cough up with
-		// one Size-number for all files sharing an uuidAndHash)
+		// Accounting is approximate, as findApproximateOldFiles() doesn't
+		// guarantee that it finds all kinds of a resource in one go (yet we
+		// delete them in one go).
+		//
+		// Next loop of the GC should fix the overall stats, tho.
 		if successfulDeletes > 0 {
 			size := float64(old[i].size)
 			fs_gc_bytes.Add(size)

--- a/cache/fs.go
+++ b/cache/fs.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -103,77 +102,14 @@ func (fs *FS) collectGarbageOnce() {
 	defer fs_gc_duration.Observe(time.Now().Sub(start).Seconds())
 	defer fs.lock.Unlock()
 
-	fs.Size = 0
+	totalSize, old, err := findApproximateOldFiles(fs.Basepath)
 
-	// Find all namespaces
-	dir, err := os.Open(fs.Basepath)
 	if err != nil {
+		fmt.Printf("Error running GC: %#v\n", err)
 		return
 	}
 
-	entries, err := dir.Readdir(0)
-	if err != nil {
-		return
-	}
-
-	old := make(fsCacheEntries, 256*len(entries))
-
-	sizes := make([]int64, len(entries))
-	allDone := sync.WaitGroup{}
-	for nsIndex, ns := range entries {
-		if !ns.IsDir() {
-			continue
-		}
-		allDone.Add(1)
-		go func(ns string, nsIndex int) {
-			defer allDone.Done()
-			// There be 256 folders - let's find the oldest one + it's size
-			// TODO: Split into ~256 go-routines for speed
-			for i := 0; i < 256; i += 1 {
-				dirname := filepath.Join(fs.Basepath, ns, fmt.Sprintf("%02x", i))
-				dir, err := os.Open(dirname)
-				if err != nil {
-					continue
-				}
-				entries, err := dir.Readdir(0)
-				if err != nil {
-					continue
-				}
-
-				oldIndex := i + 256*nsIndex
-				for _, entry := range entries {
-					if entry.IsDir() {
-						continue
-					}
-
-					// Count up sizes of everything
-					//fs.Size += entry.Size()
-					sizes[nsIndex] += entry.Size()
-
-					// Check if it's the oldest thing we've found in this directory
-					t := fileinfo_atime(entry)
-					if len(old[oldIndex].uuidAndHash) == 0 || t.Before(old[oldIndex].time) {
-						old[oldIndex].ns = ns
-						old[oldIndex].uuidAndHash = entry.Name() // TODO: Chop off extension
-						old[oldIndex].size = entry.Size()
-						old[oldIndex].time = t
-					}
-				}
-				dir.Close()
-			}
-			fs_size.WithLabelValues(ns).Set(float64(sizes[nsIndex]))
-		}(ns.Name(), nsIndex)
-	}
-	dir.Close()
-	allDone.Wait()
-
-	// Add up sizes
-	fs.Size = 0
-	for _, size := range sizes {
-		fs.Size += size
-	}
-
-	sort.Sort(old)
+	fs.Size = totalSize
 
 	// Ideally, we should delete the very oldest stuff first (and both info and
 	// asset/resource), and then re-scan that directory.

--- a/cache/fs_gc.go
+++ b/cache/fs_gc.go
@@ -1,6 +1,12 @@
 package cache
 
 import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
 	"time"
 )
 
@@ -20,3 +26,86 @@ type fsCacheEntries []fsCacheEntry
 func (f fsCacheEntries) Len() int           { return len(f) }
 func (f fsCacheEntries) Less(i, j int) bool { return f[i].time.Before(f[j].time) }
 func (f fsCacheEntries) Swap(i, j int)      { f[i], f[j] = f[j], f[i] }
+
+// Find an approximate set of oldest files.
+//
+// Currently, it does a single pass over all sub-direcotries and picks the
+// oldest file from each
+func findApproximateOldFiles(basepath string) (int64, fsCacheEntries, error) {
+	// Find all namespaces
+	dir, err := os.Open(basepath)
+	// If the path doesn't exist, we're done GC'ing
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, fsCacheEntries{}, nil
+	} else if err != nil {
+		return 0, fsCacheEntries{}, fmt.Errorf("GC Error: %w", err)
+	}
+	defer dir.Close()
+
+	entries, err := dir.Readdir(0)
+	if err != nil {
+		return 0, fsCacheEntries{}, err
+	}
+
+	// Each namespace has 256 subdirectories
+	old := make(fsCacheEntries, 256*len(entries))
+
+	sizes := make([]int64, len(entries))
+	allDone := sync.WaitGroup{}
+
+	for nsIndex, ns := range entries {
+		if !ns.IsDir() {
+			continue
+		}
+		allDone.Add(1)
+		go func(ns string, nsIndex int) {
+			defer allDone.Done()
+			// There be 256 folders - let's find the oldest one + it's size
+			// TODO: Split into ~256 go-routines for speed?
+			for i := 0; i < 256; i += 1 {
+				dirname := filepath.Join(basepath, ns, fmt.Sprintf("%02x", i))
+				dir, err := os.Open(dirname)
+				if err != nil {
+					continue
+				}
+				entries, err := dir.Readdir(0)
+				if err != nil {
+					continue
+				}
+
+				oldIndex := i + 256*nsIndex
+				for _, entry := range entries {
+					if entry.IsDir() {
+						continue
+					}
+
+					// Count up sizes of everything
+					//fs.Size += entry.Size()
+					sizes[nsIndex] += entry.Size()
+
+					// Check if it's the oldest thing we've found in this directory
+					t := fileinfo_atime(entry)
+					if len(old[oldIndex].uuidAndHash) == 0 || t.Before(old[oldIndex].time) {
+						old[oldIndex].ns = ns
+						old[oldIndex].uuidAndHash = entry.Name() // TODO: Chop off extension
+						old[oldIndex].size = entry.Size()
+						old[oldIndex].time = t
+					}
+				}
+				dir.Close()
+			}
+			fs_size.WithLabelValues(ns).Set(float64(sizes[nsIndex]))
+		}(ns.Name(), nsIndex)
+	}
+	dir.Close()
+	allDone.Wait()
+
+	// Add up sizes
+	var totalSize int64 = 0
+	for _, size := range sizes {
+		totalSize += size
+	}
+
+	sort.Sort(old)
+	return totalSize, old, nil
+}

--- a/cache/fs_gc_test.go
+++ b/cache/fs_gc_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	//"reflect"
 	//"time"
-	"fmt"
 	"math/rand"
 	"os"
 	"testing"
@@ -44,12 +43,12 @@ func TestFSFindApproximateOldFiles(t *testing.T) {
 	}
 
 	if len(entries) != 1 {
-		t.Errorf("Expected one entry, got %d", len(entries))
+		t.Fatalf("Expected one entry, got %d", len(entries))
 	}
 
 	expected := fsCacheEntry{
 		ns:          "list-old-files",
-		uuidAndHash: fmt.Sprintf("%x-%x.info", key[0:16], key[16:32]),
+		uuidAndHash: key,
 		size:        3,
 		//time: time.Now(), // TODO: Grab from FS?
 	}
@@ -58,7 +57,7 @@ func TestFSFindApproximateOldFiles(t *testing.T) {
 		t.Errorf("Expected entry ns to be %s, got %s", expected.ns, entries[0].ns)
 	}
 
-	if entries[0].uuidAndHash != expected.uuidAndHash {
+	if !bytes.Equal(entries[0].uuidAndHash, expected.uuidAndHash) {
 		t.Errorf("Expected entry UUID+Hash to be\n\t%s\ngot\n\t%s", expected.uuidAndHash, entries[0].uuidAndHash)
 	}
 }

--- a/cache/fs_gc_test.go
+++ b/cache/fs_gc_test.go
@@ -1,0 +1,64 @@
+package cache
+
+import (
+	"bytes"
+	//"reflect"
+	//"time"
+	"fmt"
+	"math/rand"
+	"os"
+	"testing"
+)
+
+func TestFSFindApproximateOldFiles(t *testing.T) {
+	f, err := NewFS(func(f *FS) { f.Quota = 100; f.Basepath = "./testdata/gc-test/" })
+	if err != nil {
+		t.Fatalf("Error creating FS: %s", err)
+	}
+	os.RemoveAll(f.Basepath) // Make sure we start empty
+	defer func() { os.RemoveAll(f.Basepath) }()
+
+	// Insert three keys, uuid.asset, uuid.info and uuid.resource
+	key := make([]byte, 32)
+	rand.Read(key)
+
+	// Insert one of each key
+	tx := f.PutTransaction("list-old-files", key)
+	for i, kind := range []Kind{KIND_INFO, KIND_ASSET, KIND_RESOURCE} {
+		err := tx.Put(1, kind, bytes.NewReader([]byte{byte(i)}))
+		if err != nil {
+			t.Fatalf("Unexpected error calling Put(): %s", err)
+		}
+	}
+	tx.Commit()
+
+	// Do a single scan and confirm the numbers are right
+	size, entries, err := findApproximateOldFiles(f.Basepath)
+
+	if err != nil {
+		t.Errorf("Unexpected error calling findApproximateOldFiles(): %s", err)
+	}
+
+	if size != 3 {
+		t.Errorf("Expected cache size to be 3, got %d", size)
+	}
+
+	if len(entries) != 1 {
+		t.Errorf("Expected one entry, got %d", len(entries))
+	}
+
+	expected := fsCacheEntry{
+		ns:          "list-old-files",
+		uuidAndHash: fmt.Sprintf("%x-%x.info", key[0:16], key[16:32]),
+		size:        3,
+		//time: time.Now(), // TODO: Grab from FS?
+	}
+
+	if entries[0].ns != expected.ns {
+		t.Errorf("Expected entry ns to be %s, got %s", expected.ns, entries[0].ns)
+	}
+
+	if entries[0].uuidAndHash != expected.uuidAndHash {
+		t.Errorf("Expected entry UUID+Hash to be\n\t%s\ngot\n\t%s", expected.uuidAndHash, entries[0].uuidAndHash)
+	}
+}

--- a/cache/fs_test.go
+++ b/cache/fs_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
-	"runtime"
 	"testing"
 )
 
@@ -119,11 +118,6 @@ func TestFSQuota(t *testing.T) {
 			t.Fatalf("Unexpected error calling Put(): %s", err)
 		}
 		tx.Commit()
-
-		// This check is unreliable on Linux -- atime precision, perhaps?
-		if runtime.GOOS == "linux" {
-			continue
-		}
 
 		// Run the garbage collector explicitly
 		f.collectGarbage()


### PR DESCRIPTION
 * Move FS-scanning logic out of main GC loop.
 * Fixes some bugs wrt. indexing of old files.
 * Attempts to coalesce multiple kinds of the same resource into one (#16)
 * Deletes all files for the same resource in one go (#16)